### PR TITLE
Version 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,10 @@ Waypackback is written in dependency-less Python, and should work wherever Pytho
 
 ## Thanks
 
-Many thanks to the following users for catching bugs and/or proposing fixes:
+Many thanks to the following users for catching bugs, fixing typos, and proposing useful features:
 
 - [@grawity](https://github.com/grawity)
 - [@taggartk](https://github.com/taggartk)
 - [@jtemplon](https://github.com/jtemplon)
+- [@jwilk](https://github.com/jwilk)
+- [@wumpus](https://github.com/wumpus)

--- a/README.md
+++ b/README.md
@@ -29,35 +29,41 @@ pip install waybackpack
 ```
 waybackpack [-h] (-d DIR | --list) [--original] [--root ROOT]
               [--prefix PREFIX] [--suffix SUFFIX] [--start START] [--end END]
-              [--quiet]
+              [--user-agent USER_AGENT] [--quiet]
               url
 
 positional arguments:
-  url                The URL of the resource you want to download.
+  url                   The URL of the resource you want to download.
 
 optional arguments:
-  -h, --help         show this help message and exit
-  -d DIR, --dir DIR  Directory to save the files.
-  --list             Instead of downloading the files, only print the list of
-                     snapshots.
-  --original         Fetch file in its original state, without snapshotted
-                     images/CSS/JS.
-  --root ROOT        The root URL from which to serve snapshotted resources.
-                     Default: 'https://web.archive.org'
-  --prefix PREFIX    Prefix to prepend to saved files. Defaults to the URL,
-                     with all non-alphanumeric characters replaced with
-                     hyphens.
-  --suffix SUFFIX    Suffix to append to saved files. Defaults to the file
-                     extension of the URL you're downloading.
-  --start START      Timestamp-string indicating the earliest snapshot to
-                     download. Should take the format YYYYMMDDhhss, though you
-                     can omit as many of the trailing digits as you like.
-                     E.g., '201501' is valid.
-  --end END          Timestamp-string indicating the latest snapshot to
-                     download. Should take the format YYYYMMDDhhss, though you
-                     can omit as many of the trailing digits as you like.
-                     E.g., '201604' is valid.
-  --quiet            Don't log progress to stderr.
+  -h, --help            show this help message and exit
+  -d DIR, --dir DIR     Directory to save the files.
+  --list                Instead of downloading the files, only print the list
+                        of snapshots.
+  --original            Fetch file in its original state, without snapshotted
+                        images/CSS/JS.
+  --root ROOT           The root URL from which to serve snapshotted
+                        resources. Default: 'https://web.archive.org'
+  --prefix PREFIX       Prefix to prepend to saved files. Defaults to the URL,
+                        with all non-alphanumeric characters replaced with
+                        hyphens.
+  --suffix SUFFIX       Suffix to append to saved files. Defaults to the file
+                        extension of the URL you're downloading.
+  --start START         Timestamp-string indicating the earliest snapshot to
+                        download. Should take the format YYYYMMDDhhss, though
+                        you can omit as many of the trailing digits as you
+                        like. E.g., '201501' is valid.
+  --end END             Timestamp-string indicating the latest snapshot to
+                        download. Should take the format YYYYMMDDhhss, though
+                        you can omit as many of the trailing digits as you
+                        like. E.g., '201604' is valid.
+  --user-agent USER_AGENT
+                        The User-Agent header to send along with your requests
+                        to the Wayback Machine. If possible, please include
+                        the phrase 'waybackpack' and your email address. That
+                        way, if you're battering their servers, they know who
+                        to contact. Default: 'waybackpack'.
+  --quiet               Don't log progress to stderr.
 ```
 
 ## Support

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import sys, os
 from setuptools import setup, find_packages
 import subprocess
 
-version = "0.0.3"
+version = "0.1.0"
 
 base_reqs = [
 ]

--- a/waybackpack/__init__.py
+++ b/waybackpack/__init__.py
@@ -1,2 +1,2 @@
 from .archive import Resource
-__version__ = "0.0.3"
+__version__ = "0.1.0"

--- a/waybackpack/cli.py
+++ b/waybackpack/cli.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from .archive import Resource, DEFAULT_ROOT
+from .archive import Resource, DEFAULT_ROOT, DEFAULT_USER_AGENT
 import argparse
 import logging
 
@@ -36,6 +36,10 @@ def parse_args():
     parser.add_argument("--end",
         help="Timestamp-string indicating the latest snapshot to download. Should take the format YYYYMMDDhhss, though you can omit as many of the trailing digits as you like. E.g., '201604' is valid.")
 
+    parser.add_argument("--user-agent",
+        help="The User-Agent header to send along with your requests to the Wayback Machine. If possible, please include the phrase 'waybackpack' and your email address. That way, if you're battering their servers, they know who to contact. Default: '{0}'.".format(DEFAULT_USER_AGENT),
+        default=DEFAULT_USER_AGENT)
+
     parser.add_argument("--quiet",
         action="store_true",
         help="Don't log progress to stderr.")
@@ -56,6 +60,7 @@ def main():
         resource.download_to(args.dir,
             original=args.original,
             root=args.root,
+            user_agent=args.user_agent,
             prefix=args.prefix,
             suffix=args.suffix)
     else:


### PR DESCRIPTION
- Adds one-second sleep on 5xx errors. (https://github.com/jsvine/waybackpack/issues/3)
- Adds customizable `User-Agent` header (cf.: https://news.ycombinator.com/item?id=11623632)