### PR TITLE
Fix --ignore-errors

### DIFF
--- a/waybackpack/pack.py
+++ b/waybackpack/pack.py
@@ -73,7 +73,7 @@ class Pack(object):
                         ex_name,
                         e
                     ))
-                    return
+                    continue
                 else:
                     raise
 


### PR DESCRIPTION
If the `--ignore-errors` option was enabled and an exception was caught, continue to the next asset instead of exiting.