### PR TITLE
Make regexp strings raw

### DIFF
--- a/waybackpack/asset.py
+++ b/waybackpack/asset.py
@@ -17,9 +17,9 @@ REMOVAL_PATTERNS = [
 ]
 
 REDIRECT_PATTERNS = [
-    re.compile(b'<p [^>]+>Got an HTTP (30\d) response at crawl time</p>'),
-    re.compile(b'<title>\s*Internet Archive Wayback Machine\s*</title>'),
-    re.compile(b'<a href="([^"]+)">Impatient\?</a>')
+    re.compile(br'<p [^>]+>Got an HTTP (30\d) response at crawl time</p>'),
+    re.compile(br'<title>\s*Internet Archive Wayback Machine\s*</title>'),
+    re.compile(br'<a href="([^"]+)">Impatient\?</a>')
 ]
 
 class Asset(object):


### PR DESCRIPTION
Fixes Python 3.6 warnings:
```
waybackpack/asset.py:20: DeprecationWarning: invalid escape sequence \d
waybackpack/asset.py:21: DeprecationWarning: invalid escape sequence \s
waybackpack/asset.py:22: DeprecationWarning: invalid escape sequence \?
```
Found using [pydiatra](https://github.com/jwilk/pydiatra).