### PR TITLE
add --no-clobber/-nc option

### DIFF
--- a/tests/test-download.py
+++ b/tests/test-download.py
@@ -4,6 +4,7 @@ import waybackpack
 import sys, os
 import shutil
 import tempfile
+from unittest.mock import MagicMock
 
 class Test(unittest.TestCase):
     def test_basic(self):
@@ -14,3 +15,20 @@ class Test(unittest.TestCase):
         dirpath = tempfile.mkdtemp()
         pack.download_to(dirpath)
         shutil.rmtree(dirpath)
+
+    def test_no_clobber(self):
+        url = "http://whitehouse.gov/"
+        snapshots = waybackpack.search(url, to_date=20010510, from_date=20010501)
+        timestamps = [ snap["timestamp"] for snap in snapshots ]
+        pack = waybackpack.Pack(url, timestamps)
+        dirpath = tempfile.mkdtemp()
+        pack.download_to(dirpath, no_clobber=True)
+        pack = waybackpack.Pack(url, timestamps)
+        for asset in pack.assets:
+            asset.fetch = MagicMock(return_value=b"asdfasdf")
+        pack.download_to(dirpath, no_clobber=True)
+        self.assertTrue(sum(asset.fetch.call_count for asset in pack.assets) < len(pack.assets))
+        shutil.rmtree(dirpath)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/waybackpack/cli.py
+++ b/waybackpack/cli.py
@@ -63,6 +63,11 @@ def parse_args():
         type=int,
         default=3)
 
+    parser.add_argument("-nc", "--no-clobber",
+        action="store_true",
+        help="If a file is already present (and >0 filesize), don't download it again."
+    )
+
     parser.add_argument("--quiet",
         action="store_true",
         help="Don't log progress to stderr.")
@@ -105,7 +110,8 @@ def main():
             args.dir,
             raw=args.raw,
             root=args.root,
-            ignore_errors=args.ignore_errors
+            ignore_errors=args.ignore_errors,
+            no_clobber=args.no_clobber
         )
     else:
         flag = "id_" if args.raw else ""

--- a/waybackpack/pack.py
+++ b/waybackpack/pack.py
@@ -40,7 +40,8 @@ class Pack(object):
     def download_to(self, directory,
         raw=False,
         root=DEFAULT_ROOT,
-        ignore_errors=False):
+        ignore_errors=False,
+        no_clobber=False):
 
         for asset in self.assets:
             path_head, path_tail = os.path.split(self.parsed_url.path)
@@ -55,6 +56,9 @@ class Pack(object):
             )
 
             filepath = os.path.join(filedir, path_tail)
+
+            if no_clobber and (os.path.exists(filepath) and os.path.getsize(filepath) > 0):
+                continue
 
             logger.info(
                 "Fetching {0} @ {1}".format(


### PR DESCRIPTION
mimicing wget, adds a no-clobber option, so that files that already exist (and have non-zero size) won't be re-downloaded

On command line
````
$ waybackpack  http://www.whitehouse.gov/ --no-clobber -d ~/Downloads/dol-wayback --to-date 199803 --from-date 199801

INFO:waybackpack.pack: Fetching http://www.whitehouse.gov/ @ 19980215014716
INFO:waybackpack.pack: Writing to /Users/merrillj/Downloads/dol-wayback/19980215014716/www.whitehouse.gov/index.html

$ waybackpack git:(master) waybackpack  http://www.whitehouse.gov/ --no-clobber -d ~/Downloads/dol-wayback --to-date 199803 --from-date 199801
````

Or in Python, `download_to(..., no_clobber=True)`

Tested in `tests/test-download.py`. 

As a note, Jeremy, the `dol.gov` URL used in the existing test there is all redirects with zero content (which confused the heck out of me) and may be worth changing to be a URL that returns content from WayBack.