### PR TITLE
Add support for proxy and dont verify certificate args

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ usage: waybackpack [-h] [--version] (-d DIR | --list) [--raw] [--root ROOT]
                    [--user-agent USER_AGENT] [--follow-redirects]
                    [--uniques-only] [--collapse COLLAPSE] [--ignore-errors]
                    [--max-retries MAX_RETRIES] [--no-clobber] [--quiet]
-                   [--progress] [--delay DELAY] [--delay-retry DELAY_RETRY]
+                   [--progress] [--delay DELAY] [--delay-retry DELAY_RETRY] [--proxy PROXY] [--no-verify-certificate]
                    url
 
 positional arguments:
@@ -100,6 +100,9 @@ options:
   --delay DELAY         Sleep X seconds between each fetch.
   --delay-retry DELAY_RETRY
                         Sleep X seconds between each post-error retry.
+  --proxy PROXY         Use a proxy to connect to the archive.org
+  --no-verify-certificate
+                        Don`t verify the certificate of archive.org
 ```
 
 ## Support

--- a/waybackpack/cli.py
+++ b/waybackpack/cli.py
@@ -130,7 +130,7 @@ def parse_args():
         "--no-verify-certificate",
         action='store_false',
         default=True,
-        help="Trust the certificate of archive.org"
+        help="Don`t verify the certificate of archive.org"
     )
 
     args = parser.parse_args()

--- a/waybackpack/cli.py
+++ b/waybackpack/cli.py
@@ -120,6 +120,19 @@ def parse_args():
         help="Sleep X seconds between each post-error retry.",
     )
 
+    parser.add_argument(
+        "--proxy",
+        default=None,
+        help="Use a proxy to connect to the archive.org"
+    )
+
+    parser.add_argument(
+        "--no-verify-certificate",
+        action='store_false',
+        default=True,
+        help="Trust the certificate of archive.org"
+    )
+
     args = parser.parse_args()
     return args
 
@@ -137,6 +150,8 @@ def main():
         follow_redirects=args.follow_redirects,
         max_retries=args.max_retries,
         delay_retry=args.delay_retry,
+        proxy=args.proxy,
+        verify=args.no_verify_certificate
     )
 
     snapshots = search(

--- a/waybackpack/session.py
+++ b/waybackpack/session.py
@@ -15,22 +15,29 @@ class Session(object):
         user_agent=DEFAULT_USER_AGENT,
         max_retries=3,
         delay_retry=5,
+        proxy=None,
+        verify=True
     ):
         self.follow_redirects = follow_redirects
         self.user_agent = user_agent
         self.max_retries = max_retries
         self.delay_retry = delay_retry
+        self.proxy = proxy
+        self.verify = verify
 
     def try_get(self, url, **kwargs):
         headers = {
             "User-Agent": self.user_agent,
         }
         try:
+            print(self.verify)
             res = requests.get(
                 url,
                 allow_redirects=self.follow_redirects,
                 headers=headers,
                 stream=True,
+                proxies={'http': self.proxy, 'https': self.proxy} if self.proxy else None,
+                verify=self.verify,
                 **kwargs
             )
 

--- a/waybackpack/session.py
+++ b/waybackpack/session.py
@@ -30,7 +30,6 @@ class Session(object):
             "User-Agent": self.user_agent,
         }
         try:
-            print(self.verify)
             res = requests.get(
                 url,
                 allow_redirects=self.follow_redirects,


### PR DESCRIPTION
Sometimes archive.org cant be accessed without proxy so i added support for proxy specifying 
CLI Example:
waybackpack url --proxy http://host:port -d output_folder

Also i added support for dont verifiying certs. It can be helpful is CA of archive.org cant be trusted (in rare cases it can be fired by using proxies)
CLI Example:
waybackpack url --proxy http://host:port --no-verify-certificate -d output_folder